### PR TITLE
Use pdfminer for PDF parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ Utilities for breaking a standards PDF into numbered clauses and exporting the r
 ## Prerequisites
 
 - **Python**: 3.10+ recommended (tested with 3.10.12).
-- **Poppler** tools: the extractor shells out to `pdftohtml -xml`. Install via your package manager, e.g. `apt install poppler-utils` or `brew install poppler`.
-- **Shell access**: The scripts invoke external commands; ensure the runtime allows `pdftohtml` execution.
-
-No third-party Python packages are required. The included `requirements.txt` exists for future extensibility.
+- **Python dependencies**: Install the requirements once (installs `pdfminer.six`). No external command-line utilities are needed anymore.
 
 ## Project Layout
 
@@ -31,11 +28,10 @@ No third-party Python packages are required. The included `requirements.txt` exi
 
 ## Quick Start
 
-### 1. Verify system dependencies
+### 1. Install Python dependencies
 
 ```bash
-pdftohtml -v   # command should exist and print usage
-python3 --version
+python3 -m pip install -r requirements.txt
 ```
 
 ### 2. Run the extractor from the CLI
@@ -72,25 +68,23 @@ Then visit [http://127.0.0.1:8000](http://127.0.0.1:8000) and upload a PDF. The 
 ## Deploying Elsewhere
 
 1. Clone or copy the repository to the target machine.
-2. Ensure `pdftohtml` (Poppler suite) is installed.
-3. Create a virtual environment if desired:
+2. Create a virtual environment if desired:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
-   (This currently loads no extra packages but keeps your deployment structured.)
-4. Use the CLI or start the web UI as shown above. For production, consider placing the script behind a proper WSGI server or reverse proxy; `src/server.py` is intentionally lightweight and lacks hardening.
+3. Use the CLI or start the web UI as shown above. For production, consider placing the script behind a proper WSGI server or reverse proxy; `src/server.py` is intentionally lightweight and lacks hardening.
 
 ## Customisation Notes
 
 - The heuristics that skip boilerplate live in `src/extract_clauses.py` (`SKIP_PATTERNS` and `looks_like_fragment`). Adjust them if your standards use different watermarks or formatting.
 - Row truncation and the modal behaviour are implemented in plain JavaScript within `src/server.py`; tweak the limit or styling in `truncate_text()` / the embedded CSS.
-- The extractor relies on Poppler layout coordinates. Different PDFs might still require refinement—validate the outputs when onboarding new document families.
+- The extractor now parses layout information via `pdfminer.six`. Different PDFs might still require refinement—validate the outputs when onboarding new document families.
 
 ## Troubleshooting
 
-- **`pdftohtml: command not found`** – install Poppler utilities per the prerequisites section.
+- **`ModuleNotFoundError: pdfminer`** – run `python3 -m pip install -r requirements.txt` to install dependencies.
 - **Empty outputs** – verify the PDF contains numeric headings following the expected pattern; table-heavy documents may need new parsing rules.
 - **Permission errors when starting the server** – avoid privileged ports or run behind a socket handed to the process by your init system.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# This project currently relies only on the Python standard library.
-# Keep this file for future third-party dependencies.
+pdfminer.six>=20221105


### PR DESCRIPTION
## Summary
- replace the Poppler `pdftohtml` dependency with a pure-Python pdfminer.six pipeline for line extraction
- extend clause extraction error handling for pdfminer-specific failures and keep downstream logic intact
- document the new workflow and dependency requirements for installs without shell access

## Testing
- python -m compileall src


------
https://chatgpt.com/codex/tasks/task_e_68d40a0d03c48325aaef3847ff19f02d