### PR TITLE
Fix pdfminer text line traversal for clause extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ Utilities for breaking a standards PDF into numbered clauses and exporting the r
 ## Prerequisites
 
 - **Python**: 3.10+ recommended (tested with 3.10.12).
-- **Poppler** tools: the extractor shells out to `pdftohtml -xml`. Install via your package manager, e.g. `apt install poppler-utils` or `brew install poppler`.
-- **Shell access**: The scripts invoke external commands; ensure the runtime allows `pdftohtml` execution.
-
-No third-party Python packages are required. The included `requirements.txt` exists for future extensibility.
+- **Python dependencies**: Install the requirements once (installs `pdfminer.six`). No external command-line utilities are needed anymore.
 
 ## Project Layout
 
@@ -31,11 +28,10 @@ No third-party Python packages are required. The included `requirements.txt` exi
 
 ## Quick Start
 
-### 1. Verify system dependencies
+### 1. Install Python dependencies
 
 ```bash
-pdftohtml -v   # command should exist and print usage
-python3 --version
+python3 -m pip install -r requirements.txt
 ```
 
 ### 2. Run the extractor from the CLI
@@ -72,25 +68,23 @@ Then visit [http://127.0.0.1:8000](http://127.0.0.1:8000) and upload a PDF. The 
 ## Deploying Elsewhere
 
 1. Clone or copy the repository to the target machine.
-2. Ensure `pdftohtml` (Poppler suite) is installed.
-3. Create a virtual environment if desired:
+2. Create a virtual environment if desired:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
-   (This currently loads no extra packages but keeps your deployment structured.)
-4. Use the CLI or start the web UI as shown above. For production, consider placing the script behind a proper WSGI server or reverse proxy; `src/server.py` is intentionally lightweight and lacks hardening.
+3. Use the CLI or start the web UI as shown above. For production, consider placing the script behind a proper WSGI server or reverse proxy; `src/server.py` is intentionally lightweight and lacks hardening.
 
 ## Customisation Notes
 
 - The heuristics that skip boilerplate live in `src/extract_clauses.py` (`SKIP_PATTERNS` and `looks_like_fragment`). Adjust them if your standards use different watermarks or formatting.
 - Row truncation and the modal behaviour are implemented in plain JavaScript within `src/server.py`; tweak the limit or styling in `truncate_text()` / the embedded CSS.
-- The extractor relies on Poppler layout coordinates. Different PDFs might still require refinement—validate the outputs when onboarding new document families.
+- The extractor now parses layout information via `pdfminer.six`. Different PDFs might still require refinement—validate the outputs when onboarding new document families.
 
 ## Troubleshooting
 
-- **`pdftohtml: command not found`** – install Poppler utilities per the prerequisites section.
+- **`ModuleNotFoundError: pdfminer`** – run `python3 -m pip install -r requirements.txt` to install dependencies.
 - **Empty outputs** – verify the PDF contains numeric headings following the expected pattern; table-heavy documents may need new parsing rules.
 - **Permission errors when starting the server** – avoid privileged ports or run behind a socket handed to the process by your init system.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# This project currently relies only on the Python standard library.
-# Keep this file for future third-party dependencies.
+pdfminer.six>=20221105

--- a/src/extract_clauses.py
+++ b/src/extract_clauses.py
@@ -6,14 +6,17 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import BinaryIO, Dict, List, Optional, Tuple, Union
-import xml.etree.ElementTree as ET
+from typing import BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 from xml.sax.saxutils import escape
 import zipfile
+
+from pdfminer.high_level import extract_pages
+from pdfminer.layout import LAParams, LTChar, LTTextContainer, LTTextLine
+from pdfminer.pdfdocument import PDFTextExtractionNotAllowed
+from pdfminer.pdfparser import PDFSyntaxError
 
 
 @dataclass
@@ -152,60 +155,75 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_pdf_structure(pdf_path: Path) -> ET.Element:
-    result = subprocess.run(
-        ["pdftohtml", "-xml", str(pdf_path), "-stdout"],
-        check=True,
-        capture_output=True,
-        text=True,
+def _iter_text_lines(container: LTTextContainer) -> Iterable[LTTextLine]:
+    for element in container:
+        if isinstance(element, LTTextLine):
+            yield element
+        elif isinstance(element, LTTextContainer):
+            yield from _iter_text_lines(element)
+
+
+def _is_bold_font(fontname: Optional[str]) -> bool:
+    if not fontname:
+        return False
+    lowered = fontname.lower()
+    return "bold" in lowered or "black" in lowered or "heavy" in lowered
+
+
+def _text_line_to_line(
+    text_line: LTTextLine,
+    page_number: int,
+    page_height: float,
+) -> Optional[Line]:
+    raw_text = text_line.get_text()
+    if not raw_text:
+        return None
+    cleaned = raw_text.replace("\r", " ").replace("\n", " ").replace("\xa0", " ")
+    if not cleaned.strip():
+        return None
+    lower = cleaned.strip().lower()
+    if lower.startswith("link to page"):
+        return None
+
+    x0, y0, x1, y1 = text_line.bbox
+    top = max(page_height - y1, 0.0)
+    width = max(x1 - x0, 0.0)
+
+    chars = [obj for obj in text_line if isinstance(obj, LTChar)]
+    font_size = max((char.size for char in chars), default=getattr(text_line, "height", 0.0))
+    total_weight = 0
+    bold_weight = 0
+    for char in chars:
+        text = char.get_text()
+        weight = len(text.strip()) or len(text)
+        total_weight += weight
+        if _is_bold_font(getattr(char, "fontname", "")):
+            bold_weight += weight
+    is_bold = total_weight > 0 and (bold_weight / total_weight) >= 0.5
+
+    chunk = TextChunk(
+        page=page_number,
+        top=top,
+        left=float(x0),
+        width=width,
+        text=cleaned.strip("\x00"),
+        font_size=float(font_size),
+        is_bold=is_bold,
     )
-    return ET.fromstring(result.stdout)
+    return Line(page=page_number, top=top, chunks=[chunk])
 
 
-def extract_lines(root: ET.Element) -> List[Line]:
-    font_sizes: Dict[str, float] = {}
-    for fontspec in root.iter("fontspec"):
-        font_sizes[fontspec.get("id")] = float(fontspec.get("size"))
-
+def extract_lines_from_pdf(pdf_path: Path) -> List[Line]:
+    laparams = LAParams(char_margin=1.0, line_margin=0.2, word_margin=0.1)
     lines: List[Line] = []
-    line_merge_threshold = 1.0
-
-    for page in root.findall("page"):
-        page_num = int(page.get("number"))
-        chunks: List[TextChunk] = []
-        for text_elem in page.findall("text"):
-            raw_text = "".join(text_elem.itertext())
-            if not raw_text:
+    for page_number, page_layout in enumerate(extract_pages(str(pdf_path), laparams=laparams), start=1):
+        page_height = float(getattr(page_layout, "height", 0.0))
+        for text_line in _iter_text_lines(page_layout):
+            line = _text_line_to_line(text_line, page_number, page_height)
+            if line is None:
                 continue
-            cleaned = raw_text.replace("\n", " ")
-            if not cleaned.strip():
-                continue
-            lower = cleaned.strip().lower()
-            if lower.startswith("link to page"):
-                continue
-            font_id = text_elem.get("font")
-            font_size = font_sizes.get(font_id, 0.0)
-            attrs = text_elem.attrib
-            chunk = TextChunk(
-                page=page_num,
-                top=float(attrs.get("top", "0")),
-                left=float(attrs.get("left", "0")),
-                width=float(attrs.get("width", "0")),
-                text=cleaned,
-                font_size=font_size,
-                is_bold="<b>" in ET.tostring(text_elem, encoding="unicode").lower(),
-            )
-            chunks.append(chunk)
-        if not chunks:
-            continue
-        chunks.sort(key=lambda c: (c.top, c.left))
-        current_line: Optional[Line] = None
-        for chunk in chunks:
-            if current_line and abs(chunk.top - current_line.top) <= line_merge_threshold:
-                current_line.add_chunk(chunk)
-            else:
-                current_line = Line(page=chunk.page, top=chunk.top, chunks=[chunk])
-                lines.append(current_line)
+            lines.append(line)
+    lines.sort(key=lambda line: (line.page, line.top, line.chunks[0].left if line.chunks else 0.0))
     return lines
 
 
@@ -350,10 +368,11 @@ def extract_pdf_clauses(pdf_path: Union[str, Path]) -> List[Clause]:
     if not resolved.exists():
         raise FileNotFoundError(resolved)
     try:
-        root = load_pdf_structure(resolved)
-    except subprocess.CalledProcessError:
-        raise
-    lines = extract_lines(root)
+        lines = extract_lines_from_pdf(resolved)
+    except PDFTextExtractionNotAllowed as exc:
+        raise PermissionError("Text extraction is not permitted for this PDF.") from exc
+    except PDFSyntaxError as exc:
+        raise ValueError(f"Failed to parse PDF structure: {exc}") from exc
     if not lines:
         raise ValueError("No text extracted from PDF.")
     clauses = build_clauses(lines)
@@ -468,11 +487,14 @@ def main() -> int:
     except FileNotFoundError:
         print(f"PDF not found: {pdf_path}", file=sys.stderr)
         return 1
-    except subprocess.CalledProcessError as exc:
-        print(f"Failed to parse PDF with pdftohtml: {exc}", file=sys.stderr)
-        return exc.returncode or 1
+    except PermissionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
+        return 1
+    except PDFSyntaxError as exc:
+        print(f"Malformed PDF: {exc}", file=sys.stderr)
         return 1
 
     json_path = output_dir / "clauses.json"


### PR DESCRIPTION
## Summary
- ensure the pdfminer traversal treats LTTextLine nodes as lines before recursing into nested containers so text is collected

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d40a0d03c48325aaef3847ff19f02d